### PR TITLE
Support for "literate" CoffeeScript (.litcoffee)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,7 +36,12 @@ module.exports = function(grunt) {
       compile: {
         files: {
           'tmp/coffee.js': ['test/fixtures/coffee1.coffee'],
-          'tmp/concat.js': ['test/fixtures/coffee1.coffee', 'test/fixtures/coffee2.coffee']
+          'tmp/litcoffee.js': ['test/fixtures/litcoffee.litcoffee'],
+          'tmp/concat.js': [
+            'test/fixtures/coffee1.coffee', 
+            'test/fixtures/coffee2.coffee', 
+            'test/fixtures/litcoffee.litcoffee'
+          ]
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "coffee-script": "~1.4.0"
+    "coffee-script": "~1.5.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.1.1",

--- a/tasks/coffee.js
+++ b/tasks/coffee.js
@@ -48,6 +48,10 @@ module.exports = function(grunt) {
   var compileCoffee = function(srcFile, options) {
     options = grunt.util._.extend({filename: srcFile}, options);
 
+    if (require('path').extname(srcFile) === '.litcoffee') {
+      options.literate = true;
+    }
+
     var srcCode = grunt.file.read(srcFile);
 
     try {

--- a/test/coffee_test.js
+++ b/test/coffee_test.js
@@ -17,11 +17,15 @@ exports.coffee = {
   compile: function(test) {
     'use strict';
 
-    test.expect(2);
+    test.expect(3);
 
     var actual = readFile('tmp/coffee.js');
     var expected = readFile('test/expected/coffee.js');
     test.equal(expected, actual, 'should compile coffeescript to javascript');
+
+    actual = readFile('tmp/litcoffee.js');
+    expected = readFile('test/expected/litcoffee.js');
+    test.equal(expected, actual, 'should compile literate coffeescript to javascript');
 
     actual = readFile('tmp/concat.js');
     expected = readFile('test/expected/concat.js');

--- a/test/expected/concat.js
+++ b/test/expected/concat.js
@@ -12,3 +12,9 @@ HelloWorld = (function() {
 
 
 console.log('hi');
+
+var sayHello;
+
+sayHello = function() {
+  return console.log('hi');
+};

--- a/test/expected/litcoffee.js
+++ b/test/expected/litcoffee.js
@@ -1,0 +1,5 @@
+var sayHello;
+
+sayHello = function() {
+  return console.log('hi');
+};

--- a/test/fixtures/litcoffee.litcoffee
+++ b/test/fixtures/litcoffee.litcoffee
@@ -1,0 +1,7 @@
+Begin function declaration.
+
+    sayHello = ->
+
+Print a greeting.
+
+      console.log 'hi'


### PR DESCRIPTION
This adds support for the new ‘literate’ CoffeeScript mode [announced this morning](http://coffeescript.org/#literate) as part of CoffeeScript 1.5.

Changes:
- bumped `coffee-script` dependency to version 1.5
- modified coffee.js task to enable `literal` option, depending on file extension
- added new test case

To use ‘literate’ mode, you just need to use a `.litcoffee` file extension instead of `.coffee`.
