### PR TITLE
Update coffee-script to v1.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "coffee-script": "~1.5.0"
+    "coffee-script": "~1.6.1"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.2.0",


### PR DESCRIPTION
New release includes support for source-maps at the compiler level, and fixes some compilation issues. 

Full changelog available at https://github.com/jashkenas/coffee-script/compare/1.5.0...1.6.1

You will likely want to update the version number for this project if you decide to merge this.
