### PR TITLE
Support script concatenation prior to compilation using join option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,7 +25,7 @@ module.exports = function(grunt) {
 
     // Before generating any new files, remove any previously-created files.
     clean: {
-      tests: ['tmp/bare', 'tmp/default', 'tmp/maps']
+      tests: ['tmp/bare', 'tmp/default', 'tmp/join']
     },
 
     // Configuration to be run (and then tested).
@@ -54,6 +54,31 @@ module.exports = function(grunt) {
             'test/fixtures/coffee1.coffee',
             'test/fixtures/coffee2.coffee',
             'test/fixtures/litcoffee.litcoffee'
+          ]
+        }
+      },
+      compileJoined: {
+        options: {
+          join: true
+        },
+        files: {
+          'tmp/join/coffee.js': ['test/fixtures/coffee1.coffee'],
+          'tmp/join/join.js': [
+            'test/fixtures/coffee1.coffee',
+            'test/fixtures/coffee2.coffee'
+          ]
+        }
+      },
+      compileBareJoined: {
+        options: {
+          bare: true,
+          join: true
+        },
+        files: {
+          'tmp/join/bareCoffee.js': ['test/fixtures/coffee1.coffee'],
+          'tmp/join/bareJoin.js': [
+            'test/fixtures/coffee1.coffee',
+            'test/fixtures/coffee2.coffee'
           ]
         }
       }

--- a/test/coffee_test.js
+++ b/test/coffee_test.js
@@ -1,5 +1,6 @@
 var grunt = require('grunt');
 var fs = require('fs');
+var coffee = require('../tasks/coffee.js');
 
 function readFile(file) {
   'use strict';
@@ -43,7 +44,7 @@ exports.coffee = {
     assertFileEquality(test,
       'tmp/bare/concat.js',
       'test/expected/bare/concat.js',
-      'Should compile multiple coffeescript files to a single, unwrapped javascript file');
+      'Should compile coffeescript files without wrappers and concatenate them into a single javascript file');
 
     test.done();
   },
@@ -70,7 +71,34 @@ exports.coffee = {
     assertFileEquality(test,
       'tmp/default/concat.js',
       'test/expected/default/concat.js',
-      'Should compile multiple coffeescript files to a single, wrapped javascript file');
+      'Should compile coffeescript files with wrappers and concatenate them into a single javascript file');
+
+    test.done();
+  },
+  compileJoined: function(test) {
+    'use strict';
+
+    test.expect(4);
+
+    assertFileEquality(test,
+      'tmp/join/coffee.js',
+      'test/expected/default/coffee.js',
+      'Compilation of one file with join enabled should match normal compilation');
+
+    assertFileEquality(test,
+      'tmp/join/join.js',
+      'test/expected/join/join.js',
+      'Should concatenate coffeescript files prior to compilation into a single javascript file');
+
+    assertFileEquality(test,
+      'tmp/join/bareCoffee.js',
+      'test/expected/bare/coffee.js',
+      'Bare compilation of one file with join enabled should match bare compilation');
+
+    assertFileEquality(test,
+      'tmp/join/bareJoin.js',
+      'test/expected/join/bareJoin.js',
+      'Bare compilation of multiple join files should be equivalent to concatenated compilation');
 
     test.done();
   }

--- a/test/expected/join/bareJoin.js
+++ b/test/expected/join/bareJoin.js
@@ -1,0 +1,13 @@
+var HelloWorld;
+
+HelloWorld = (function() {
+
+  function HelloWorld() {}
+
+  HelloWorld.test = 'test';
+
+  return HelloWorld;
+
+})();
+
+console.log('hi');

--- a/test/expected/join/join.js
+++ b/test/expected/join/join.js
@@ -1,0 +1,16 @@
+(function() {
+  var HelloWorld;
+
+  HelloWorld = (function() {
+
+    function HelloWorld() {}
+
+    HelloWorld.test = 'test';
+
+    return HelloWorld;
+
+  })();
+
+  console.log('hi');
+
+}).call(this);


### PR DESCRIPTION
This change allows for the concatenation of CoffeeScript files prior to compilation (in a fashion similar to the CoffeeScript compiler). This is achieved by setting the newly introduced 'join' option to true.

This is in advance of adding sourceMap support. When concatenating multiple CoffeeScript files into a single JavaScript file using this plugin, sourceMaps will be irrelevant for files concatenated after compilation. The 'join' option paves the way for generation of a relevant sourceMap.
