### PR TITLE
Include filepath and linenumber in compile error messages.

### DIFF
--- a/tasks/coffee.js
+++ b/tasks/coffee.js
@@ -90,6 +90,8 @@ module.exports = function(grunt) {
       return require('coffee-script').compile(code, options);
     } catch (e) {
       grunt.log.error(e);
+      grunt.log.error('In file: '+filepath);
+      grunt.log.error('On line: '+e.location.first_line);
       grunt.fail.warn('CoffeeScript failed to compile.');
     }
   };


### PR DESCRIPTION
It can be pretty frustrating to have a coffeescript compile error pop up without reference to the file where the error is. This simple addition provides some context.
