### PR TITLE
Improved compilation error output

### DIFF
--- a/tasks/coffee.js
+++ b/tasks/coffee.js
@@ -171,9 +171,28 @@ module.exports = function(grunt) {
     try {
       return require('coffee-script').compile(code, options);
     } catch (e) {
+
+      var firstColumn = e.location.first_column;
+      var firstLine = e.location.first_line;
+      var codeLine = code.split('\n')[firstLine];
+      var errorArrows = '\x1B[31m>>\x1B[39m ';
+      var offendingCharacter;
+
+      if (firstColumn < codeLine.length) {
+        offendingCharacter = '\x1B[31m' + codeLine[firstColumn] + '\x1B[39m';
+      } else {
+        offendingCharacter = '';
+      }
+
       grunt.log.error(e);
-      grunt.log.error('In file: '+filepath);
-      grunt.log.error('On line: '+e.location.first_line);
+      grunt.log.error('In file: ' + filepath);
+      grunt.log.error('On line: ' + firstLine);
+      // Log erroneous line and highlight offending character
+      // grunt.log.error trims whitespace so we have to use grunt.log.writeln
+      grunt.log.writeln(errorArrows + codeLine.substring(0, firstColumn) +
+                        offendingCharacter + codeLine.substring(firstColumn + 1));
+      grunt.log.writeln(errorArrows + grunt.util.repeat(firstColumn, ' ') +
+                        '\x1B[31m^\x1B[39m ');
       grunt.fail.warn('CoffeeScript failed to compile.');
     }
   };


### PR DESCRIPTION
Currently CoffeeScript compilation errors are outputted like this:

```
>> SyntaxError: unmatched }
>> In file: main.coffee
>> On line: 15
```

I added logging of the erroneous line and an arrow pointing to the offending character just like the CoffeeScript command line compiler does

```
>> SyntaxError: unmatched }
>> In file: main.coffee
>> On line: 15
>> foo =  }
>>        ^
```
