### PR TITLE
Add test for compiling multiple litcoffee files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,6 +21,11 @@ module.exports = function(grunt) {
     'test/fixtures/coffee2.coffee'
   ];
 
+  var uniformLiterateConcatFixtures = [
+    'test/fixtures/litcoffee.litcoffee',
+    'test/fixtures/litcoffee2.litcoffee'
+  ];
+
   // Project configuration.
   grunt.initConfig({
     jshint: {
@@ -66,7 +71,8 @@ module.exports = function(grunt) {
         },
         files: {
           'tmp/join/coffee.js': ['test/fixtures/coffee1.coffee'],
-          'tmp/join/join.js': uniformConcatFixtures
+          'tmp/join/join.js': uniformConcatFixtures,
+          'tmp/join/litJoin.js': uniformLiterateConcatFixtures
         }
       },
       compileBareJoined: {
@@ -97,6 +103,18 @@ module.exports = function(grunt) {
           cwd: 'test/fixtures/',
           src: ['coffee1.coffee', 'litcoffee.litcoffee'],
           dest: 'tmp/eachMap/',
+          ext: '.js'
+        }]
+      },
+      compileEachLiterateMap: {
+        options: {
+          sourceMap: true
+        },
+        files: [{
+          expand: true,
+          cwd: 'test/fixtures/',
+          src: ['litcoffee.litcoffee'],
+          dest: 'tmp/eachLiterateMap/',
           ext: '.js'
         }]
       },

--- a/test/coffee_test.js
+++ b/test/coffee_test.js
@@ -77,7 +77,7 @@ exports.coffee = {
   compileJoined: function(test) {
     'use strict';
 
-    test.expect(4);
+    test.expect(5);
 
     assertFileEquality(test,
       'tmp/join/coffee.js',
@@ -98,6 +98,11 @@ exports.coffee = {
       'tmp/join/bareJoin.js',
       'test/expected/join/bareJoin.js',
       'Bare compilation of multiple join files should be equivalent to concatenated compilation');
+
+    assertFileEquality(test,
+      'tmp/join/litJoin.js',
+      'test/expected/join/litJoin.js',
+      'Compilation of multiple literate coffee files should be equivalent to contatenated compilation.');
 
     test.done();
   },
@@ -182,6 +187,23 @@ exports.coffee = {
       'tmp/eachMap/litcoffee.map',
       'test/expected/eachMap/litcoffee.map',
       'Separate compilation of coffee and litcoffee files with source maps should generate map');
+
+    test.done();
+  },
+  compileEachLiterateMap: function(test) {
+    'use strict';
+
+    test.expect(2);
+
+    assertFileEquality(test,
+      'tmp/eachLiterateMap/litcoffee.js',
+      'test/expected/eachLiterateMap/litcoffee.js',
+      'Compilation of multiple literate coffee files with source maps should generate javascript');
+
+    assertFileEquality(test,
+      'tmp/eachLiterateMap/litcoffee2.js',
+      'test/expected/eachLiterateMap/litcoffee2.js',
+      'Compilation of multiple literate coffee files with source maps should generate javascript');
 
     test.done();
   }

--- a/test/expected/eachLiterateMap/litcoffee.js
+++ b/test/expected/eachLiterateMap/litcoffee.js
@@ -1,0 +1,8 @@
+(function() {
+  var sayHello;
+
+  sayHello = function() {
+    return console.log('hi');
+  };
+
+}).call(this);

--- a/test/expected/eachLiterateMap/litcoffee2.js
+++ b/test/expected/eachLiterateMap/litcoffee2.js
@@ -1,0 +1,4 @@
+(function() {
+  console.log('something');
+
+}).call(this);

--- a/test/expected/join/litJoin.js
+++ b/test/expected/join/litJoin.js
@@ -1,0 +1,10 @@
+(function() {
+  var sayHello;
+
+  sayHello = function() {
+    return console.log('hi');
+  };
+
+  console.log('something');
+
+}).call(this);

--- a/test/fixtures/litcoffee2.litcoffee
+++ b/test/fixtures/litcoffee2.litcoffee
@@ -1,0 +1,3 @@
+Print something.
+
+      console.log 'something'


### PR DESCRIPTION
Related to #64, this shows the issue with attempting to compile multiple literate CoffeeScript files.

The test isn't really ideal because (instead of failing) it generates a warning, causing the tests to be aborted, however there didn't seem to be a framework in place for doing more targeted unit tests. So I figure this is better than nothing in that it at least shows the issue (:
