### PR TITLE
fixed issue #68

### DIFF
--- a/tasks/coffee.js
+++ b/tasks/coffee.js
@@ -89,7 +89,7 @@ module.exports = function(grunt) {
         sourceFiles: mapOptions.sourceFiles
       }, options);
 
-    var output = compileCoffee(mapOptions.code, options);
+    var output = compileCoffee(mapOptions.code, options, mapOptions.sourceFiles[0]);
     prependHeader(output, paths);
     return output;
   };


### PR DESCRIPTION
error reports now include the source file name when source maps are created.
