### PR TITLE
Updated documentation for clarification and to include the 'flatten' option in glob_to_multiple example

### DIFF
--- a/docs/coffee-examples.md
+++ b/docs/coffee-examples.md
@@ -50,4 +50,4 @@ coffee: {
 }
 ```
 
-For more examples on how to use the `expand` API shown in the `glob_to_multiple` example, see "Building the files object dynamically" in the grunt wiki entry [Configuring Tasks](http://gruntjs.com/configuring-tasks).
+For more examples on how to use the `expand` API to manipulate the default dynamic path construction in the `glob_to_multiple` examples, see "Building the files object dynamically" in the grunt wiki entry [Configuring Tasks](http://gruntjs.com/configuring-tasks).


### PR DESCRIPTION
Updated documentation to include the 'flatten' option in glob_to_multiple example (didn't warrant its own use-case example). Added detail about finding more information for the 'expand' API in the glob_to_multiple example.

I updated the example in /docs, but was unsure if I needed to generate the readme, and if so, how.
