### PR TITLE
Option: bring your own compiler

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,7 +36,7 @@ module.exports = function(grunt) {
 
     // Before generating any new files, remove any previously-created files.
     clean: {
-      tests: ['tmp/bare', 'tmp/default', 'tmp/join']
+      tests: ['tmp/bare', 'tmp/default', 'tmp/join', 'tmp/customCompiler']
     },
 
     // Configuration to be run (and then tested).
@@ -108,6 +108,18 @@ module.exports = function(grunt) {
         files: {
           'tmp/maps/coffeeBare.js': ['test/fixtures/coffee1.coffee'],
           'tmp/maps/coffeeBareJoin.js': uniformConcatFixtures
+        }
+      },
+      compileCustomCompiler: {
+        options: {
+          compiler: require('coffee-script'),
+          bare: true
+        },
+        files: {
+          'tmp/customCompiler/coffee.js': ['test/fixtures/coffee1.coffee'],
+          'tmp/customCompiler/litcoffee.js': ['test/fixtures/litcoffee.litcoffee'],
+          'tmp/customCompiler/litcoffeemd.js': ['test/fixtures/litcoffee.coffee.md'],
+          'tmp/customCompiler/concat.js': mixedConcatFixtures
         }
       }
     },

--- a/docs/coffee-examples.md
+++ b/docs/coffee-examples.md
@@ -46,8 +46,18 @@ coffee: {
     src: ['*.coffee'],
     dest: 'path/to/dest/',
     ext: '.js'
+  },
+
+  alternate_compiler: {
+    options: {
+      compiler: require('coffee-script')
+    },
+    expand: true,
+    cwd: 'src',
+    dest: 'build',
+    src: ['**/*.coffee'],
+    ext: '.js'
   }
-}
 ```
 
 For more examples on how to use the `expand` API to manipulate the default dynamic path construction in the `glob_to_multiple` examples, see "Building the files object dynamically" in the grunt wiki entry [Configuring Tasks](http://gruntjs.com/configuring-tasks).

--- a/docs/coffee-options.md
+++ b/docs/coffee-options.md
@@ -22,3 +22,12 @@ Type: `boolean`
 Default: `false`
 
 Compile JavaScript and create a .map file linking it to the CoffeeScript source. When compiling multiple .coffee files to a single .js file, concatenation occurs as though the 'join' option is enabled. The concatenated CoffeeScript is written into the output directory, and becomes the target for source mapping.
+
+## compiler
+Type: `object`
+Default: `undefined`
+
+If provided, the compiler is expected to be an instance of the npm package 'coffee-script' or something
+that behaves as if it were.  This can be used to build with an alternate version of coffee-script or to
+build with a fork of coffee-script.  Typically, the user will specify the compiler using `compiler: require('coffee-script')` where an alternate version of coffee-script has been specified by the package as
+a direct dependency.

--- a/tasks/coffee.js
+++ b/tasks/coffee.js
@@ -164,13 +164,13 @@ module.exports = function(grunt) {
     }
 
     try {
-      return require('coffee-script').compile(code, options);
+      return (options['compiler'] || require('coffee-script')).compile(code, options);
     } catch (e) {
       if (e.location == null ||
           e.location.first_column == null ||
           e.location.first_line == null) {
         grunt.log.error('Got an unexpected exception ' +
-                        'from the coffee-script compiler. ' + 
+                        'from the coffee-script compiler. ' +
                         'The original exception was: ' +
                         e);
         grunt.log.error('(The coffee-script compiler should not raise *unexpected* exceptions. ' +
@@ -182,13 +182,13 @@ module.exports = function(grunt) {
         var codeLine = code.split('\n')[firstLine];
         var errorArrows = '\x1B[31m>>\x1B[39m ';
         var offendingCharacter;
-  
+
         if (firstColumn < codeLine.length) {
           offendingCharacter = '\x1B[31m' + codeLine[firstColumn] + '\x1B[39m';
         } else {
           offendingCharacter = '';
         }
-  
+
         grunt.log.error(e);
         grunt.log.error('In file: ' + filepath);
         grunt.log.error('On line: ' + firstLine);

--- a/test/coffee_test.js
+++ b/test/coffee_test.js
@@ -184,5 +184,32 @@ exports.coffee = {
       'Separate compilation of coffee and litcoffee files with source maps should generate map');
 
     test.done();
-  }
+  },
+  compileCustomCompiler: function(test) {
+    'use strict';
+
+    test.expect(4);
+
+    assertFileEquality(test,
+      'tmp/customCompiler/coffee.js',
+      'test/expected/customCompiler/coffee.js',
+      'Should compile coffeescript to unwrapped javascript with user-specified compiler');
+
+    assertFileEquality(test,
+      'tmp/customCompiler/litcoffee.js',
+      'test/expected/customCompiler/litcoffee.js',
+      'Should compile literate coffeescript to unwrapped javascript with user-specified compiler');
+
+    assertFileEquality(test,
+      'tmp/customCompiler/litcoffeemd.js',
+      'test/expected/customCompiler/litcoffee.js',
+      'Should compile literate coffeescript to unwrapped javascript with user-specified compiler');
+
+    assertFileEquality(test,
+      'tmp/customCompiler/concat.js',
+      'test/expected/customCompiler/concat.js',
+      'Should compile coffeescript files without wrappers and concatenate them into a single javascript file with user-specified compiler');
+
+    test.done();
+  },
 };

--- a/test/expected/customCompiler/coffee.js
+++ b/test/expected/customCompiler/coffee.js
@@ -1,0 +1,10 @@
+var HelloWorld;
+
+HelloWorld = (function() {
+  function HelloWorld() {}
+
+  HelloWorld.test = 'test';
+
+  return HelloWorld;
+
+})();

--- a/test/expected/customCompiler/concat.js
+++ b/test/expected/customCompiler/concat.js
@@ -1,0 +1,18 @@
+var HelloWorld;
+
+HelloWorld = (function() {
+  function HelloWorld() {}
+
+  HelloWorld.test = 'test';
+
+  return HelloWorld;
+
+})();
+
+console.log('hi');
+
+var sayHello;
+
+sayHello = function() {
+  return console.log('hi');
+};

--- a/test/expected/customCompiler/litcoffee.js
+++ b/test/expected/customCompiler/litcoffee.js
@@ -1,0 +1,5 @@
+var sayHello;
+
+sayHello = function() {
+  return console.log('hi');
+};


### PR DESCRIPTION
Hi,

I'm building an uber-task that will use grunt-contrib-coffee to compile with a non-standard version of coffee-script.  I imagine others may have the need to hand-pick their versions from the official repo or to use a fork as I do.  So this change allows the builder to provide their own instance of the compiler.

---

Add option to provide the coffee-script compiler that grunt-contrib-coffee will use to compile.

Usage example:

```
coffee: {
  build: {
    options: {
      compiler: require('coffee-script')
    },
    expand: true,
    cwd: 'src',
    dest: 'build',
    src: ['**/*.coffee'],
    ext: '.js'
  }
}
```
