### PR TITLE
修正换行符.

### DIFF
--- a/tasks/coffee.js
+++ b/tasks/coffee.js
@@ -164,7 +164,7 @@ module.exports = function(grunt) {
     }
 
     try {
-      return require('coffee-script').compile(code, options);
+      return grunt.util.normalizelf(require('coffee-script').compile(code, options));
     } catch (e) {
       if (e.location == null ||
           e.location.first_column == null ||


### PR DESCRIPTION
`coffee-script` 输出的换行符为 `\n`, 而在Windows平台下换行符应该为 `\r\n`,
所以此处使用 `grunt.util.normalizelf` 来对换行符统一一下.
