### PR TITLE
Add amdDefineWrap support to wrap joined in a CommonJS-style AMD wrapper

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -79,6 +79,25 @@ module.exports = function(grunt) {
           'tmp/join/bareJoin.js': uniformConcatFixtures
         }
       },
+      compileBareJoinedWrapped: {
+        options: {
+          amdDefineWrap: true
+        },
+        files: {
+          'tmp/join/bareCoffeeWrap.js': ['test/fixtures/coffee1.coffee'],
+          'tmp/join/bareJoinWrap.js': uniformConcatFixtures
+        }
+      },
+      compileBareJoinedWrappedMap: {
+        options: {
+          sourceMap: true,
+          amdDefineWrap: true
+        },
+        files: {
+          'tmp/join/bareWrapMap.js': ['test/fixtures/coffee1.coffee'],
+          'tmp/join/bareJoinWrapMap.js': uniformConcatFixtures
+        }
+      },
       compileMaps: {
         options: {
           sourceMap: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# grunt-contrib-coffee [![Build Status](https://secure.travis-ci.org/gruntjs/grunt-contrib-coffee.png?branch=master)](http://travis-ci.org/gruntjs/grunt-contrib-coffee)
+# grunt-contrib-coffee v0.7.0 [![Build Status](https://travis-ci.org/gruntjs/grunt-contrib-coffee.png?branch=master)](https://travis-ci.org/gruntjs/grunt-contrib-coffee)
 
 > Compile CoffeeScript files to JavaScript.
 
@@ -50,6 +50,17 @@ Type: `boolean`
 Default: `false`
 
 Compile JavaScript and create a .map file linking it to the CoffeeScript source. When compiling multiple .coffee files to a single .js file, concatenation occurs as though the 'join' option is enabled. The concatenated CoffeeScript is written into the output directory, and becomes the target for source mapping.
+
+#### amdDefineWrap
+Type: `boolean`
+Default: false
+
+Will wrap joined CoffeeScript in a define function. Use to reuse CommonJS modules on the web.  If `true` is passed 'join' and 'bare' will both overridden to `true`.
+```js
+define (require, exports, module) ->
+  //bare, joined CoffeeScript here.
+  return exports
+```
 ### Usage Examples
 
 ```js
@@ -129,4 +140,4 @@ For more examples on how to use the `expand` API to manipulate the default dynam
 
 Task submitted by [Eric Woroshow](http://ericw.ca/)
 
-*This file was generated on Fri Apr 19 2013 09:49:08.*
+*This file was generated on Tue Sep 17 2013 15:17:34.*

--- a/docs/coffee-options.md
+++ b/docs/coffee-options.md
@@ -22,3 +22,14 @@ Type: `boolean`
 Default: `false`
 
 Compile JavaScript and create a .map file linking it to the CoffeeScript source. When compiling multiple .coffee files to a single .js file, concatenation occurs as though the 'join' option is enabled. The concatenated CoffeeScript is written into the output directory, and becomes the target for source mapping.
+
+## amdDefineWrap
+Type: `boolean`
+Default: false
+
+Will wrap joined CoffeeScript in a define function. Use to reuse CommonJS modules on the web.  If `true` is passed 'join' and 'bare' will both overridden to `true`.
+```js
+define (require, exports, module) ->
+  //bare, joined CoffeeScript here.
+  return exports
+```

--- a/test/coffee_test.js
+++ b/test/coffee_test.js
@@ -101,6 +101,40 @@ exports.coffee = {
 
     test.done();
   },
+  compileBareJoinedWrapped: function(test) {
+    'use strict';
+
+    test.expect(2);
+    
+    assertFileEquality(test,
+      'tmp/join/bareCoffeeWrap.js',
+      'test/expected/bare/coffeeWrap.js',
+      'Bare compilation of one file with join, wrap enabled should match bare compilation');
+    
+    assertFileEquality(test,
+      'tmp/join/bareJoinWrap.js',
+      'test/expected/join/bareJoinWrap.js',
+      'Compilation of multiple files with join, wrap enabled should match normal compilation');
+    
+    test.done();
+  },
+  compileBareJoinedWrappedMap: function(test) {
+    'use strict';
+
+    test.expect(2);
+    
+    assertFileEquality(test,
+      'tmp/join/bareWrapMap.js.map',
+      'test/expected/maps/bareCoffeeWrap.js.map',
+      'Compilation of single file with source maps, wrap should generate map');
+    
+    assertFileEquality(test,
+      'tmp/join/bareJoinWrapMap.js.map',
+      'test/expected/maps/bareJoinWrap.js.map',
+      'Compilation of multiple files with source maps, wrap should generate map');
+    
+    test.done();
+  },
   compileMaps: function(test) {
     'use strict';
 

--- a/test/expected/bare/coffeeWrap.js
+++ b/test/expected/bare/coffeeWrap.js
@@ -1,0 +1,12 @@
+define(function(require, exports, module) {
+  var HelloWorld;
+  HelloWorld = (function() {
+    function HelloWorld() {}
+
+    HelloWorld.test = 'test';
+
+    return HelloWorld;
+
+  })();
+  return exports;
+});

--- a/test/expected/join/bareJoinWrap.js
+++ b/test/expected/join/bareJoinWrap.js
@@ -1,0 +1,13 @@
+define(function(require, exports, module) {
+  var HelloWorld;
+  HelloWorld = (function() {
+    function HelloWorld() {}
+
+    HelloWorld.test = 'test';
+
+    return HelloWorld;
+
+  })();
+  console.log('hi');
+  return exports;
+});

--- a/test/expected/maps/bareCoffeeWrap.js.map
+++ b/test/expected/maps/bareCoffeeWrap.js.map
@@ -1,0 +1,10 @@
+{
+  "version": 3,
+  "file": "bareWrapMap.js",
+  "sourceRoot": "../../test/fixtures/",
+  "sources": [
+    "coffee1.coffee"
+  ],
+  "names": [],
+  "mappings": "AAAA,IAAA,MAAA;;AAAM,CAAN;CACE;;CAAA,CAAA,CAAO,CAAP,EAAA,IAAC;;CAAD;;CADF"
+}

--- a/test/expected/maps/bareJoinWrap.js.map
+++ b/test/expected/maps/bareJoinWrap.js.map
@@ -1,0 +1,10 @@
+{
+  "version": 3,
+  "file": "bareJoinWrapMap.js",
+  "sourceRoot": "",
+  "sources": [
+    "bareJoinWrapMap.src.coffee"
+  ],
+  "names": [],
+  "mappings": "AAAA,CAAO,CAAU,CAAV,GAAP,CAAO,EAAC;CACN,KAAA,IAAA;CAAA,CAAM;CACJ;;CAAA,EAAO,CAAP,EAAA,IAAC;;CAAD;;CADF;CAAA,CAEA,CAAA,CAAA,GAAO;CACP,MAAA,EAAO;CAJF"
+}

--- a/test/expected/maps/coffeeBareJoinWrap.src.coffee
+++ b/test/expected/maps/coffeeBareJoinWrap.src.coffee
@@ -1,0 +1,5 @@
+define "myModule", (require, exports, module) ->
+  class HelloWorld
+    @test: 'test'
+  console.log('hi')
+  return exports


### PR DESCRIPTION
We wanted a way to wrap our require/exports dependent files in a CommonJS-style AMD wrapper for use in the browser.

Authored by @longoria and @joerozek 
