### PR TITLE
Update to coffee-script 1.6.3 and the newer map comment style

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "coffee-script": "~1.6.2"
+    "coffee-script": "~1.6.3"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.4",

--- a/tasks/coffee.js
+++ b/tasks/coffee.js
@@ -135,7 +135,7 @@ module.exports = function(grunt) {
 
   var appendFooter = function (output, paths) {
     // Add sourceMappingURL to file footer
-    output.js = output.js + '\n/*\n//# sourceMappingURL=' + paths.mapFileName + '\n*/';
+    output.js = output.js + '\n\n//# sourceMappingURL=' + paths.mapFileName + '\n';
   };
 
   var concatInput = function (files, options) {


### PR DESCRIPTION
Coffeescript 1.6.3 changed the comment style of maps from.  Newer tools relying on 1.6.3 choke on the /\* */.

/*
//#..
*/

to

//#..
