### PR TITLE
Add joinExt option

### DIFF
--- a/tasks/coffee.js
+++ b/tasks/coffee.js
@@ -18,6 +18,7 @@ module.exports = function(grunt) {
       bare: false,
       join: false,
       sourceMap: false,
+      joinExt: '.src.coffee',
       separator: grunt.util.linefeed
     });
 
@@ -78,7 +79,7 @@ module.exports = function(grunt) {
     var mapOptions, filepath;
 
     if (files.length > 1) {
-      mapOptions = createOptionsForJoin(files, paths, options.separator);
+      mapOptions = createOptionsForJoin(files, paths, options.separator, options.joinExt);
     } else {
       mapOptions = createOptionsForFile(files[0], paths);
       filepath = files[0];
@@ -109,9 +110,9 @@ module.exports = function(grunt) {
     }
   };
 
-  var createOptionsForJoin = function (files, paths, separator) {
+  var createOptionsForJoin = function (files, paths, separator, joinExt) {
     var code = concatFiles(files, separator);
-    var targetFileName = paths.destName + '.src.coffee';
+    var targetFileName = paths.destName + joinExt;
     grunt.file.write(paths.destDir + targetFileName, code);
 
     return {


### PR DESCRIPTION
When joining many literate CoffeeScript files, the generated
joined file still use the `coffee` extension. The joined
file can't be compiled or documented properly due to that.

Passing `.src.litcoffee` or `.src.coffee.md` in `joinExt` fix it.
