### PR TITLE
Fix folders of nested sourcemaps.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,7 +36,7 @@ module.exports = function(grunt) {
 
     // Before generating any new files, remove any previously-created files.
     clean: {
-      tests: ['tmp/bare', 'tmp/default', 'tmp/join', 'tmp/sourceMapDir1', 'tmp/sourceMapDir2']
+      tests: ['tmp/bare', 'tmp/default', 'tmp/join', 'tmp/sourceMapDir1', 'tmp/sourceMapDir2', 'tmp/nest']
     },
 
     // Configuration to be run (and then tested).
@@ -117,6 +117,15 @@ module.exports = function(grunt) {
         files: {
           'tmp/maps/coffeeBare.js': ['test/fixtures/coffee1.coffee'],
           'tmp/maps/coffeeBareJoin.js': uniformConcatFixtures
+        }
+      },
+      compileNested: {
+        options: {
+          sourceMap: true
+        },
+        files: {
+          'tmp/nest/1/coffee.js': ['test/fixtures/coffee1.coffee'],
+          'tmp/nest/2/coffee.js': ['test/fixtures/coffee1.coffee']
         }
       }
     },

--- a/tasks/coffee.js
+++ b/tasks/coffee.js
@@ -28,8 +28,8 @@ module.exports = function(grunt) {
       if (options.sourceMap === true) {
         var paths = createOutputPaths(f.dest);
         // add sourceMapDir to options object
-        options = _.extend({ sourceMapDir: paths.destDir }, options);
-        writeFileAndMap(paths, compileWithMaps(validFiles, options, paths), options);
+        var fileOptions = _.extend({ sourceMapDir: paths.destDir }, options);
+        writeFileAndMap(paths, compileWithMaps(validFiles, fileOptions, paths), fileOptions);
       } else if (options.join === true) {
         writeFile(f.dest, concatInput(validFiles, options));
       } else {

--- a/test/coffee_test.js
+++ b/test/coffee_test.js
@@ -201,5 +201,22 @@ exports.coffee = {
       'Compilation of single file with alternate source map dir should generate map');
 
     test.done();
+  },
+  compileNested: function(test) {
+    'use strict';
+
+    test.expect(2);
+
+    assertFileEquality(test,
+      'tmp/nest/1/coffee.js.map',
+      'test/expected/maps/coffeeNested.js.map',
+      'Compilation of nested maps should respect path info');
+
+    assertFileEquality(test,
+      'tmp/nest/2/coffee.js.map',
+      'test/expected/maps/coffeeNested.js.map',
+      'Compilation of nested maps should change per file');
+
+    test.done();
   }
 };

--- a/test/expected/maps/coffeeNested.js.map
+++ b/test/expected/maps/coffeeNested.js.map
@@ -1,0 +1,10 @@
+{
+  "version": 3,
+  "file": "coffee.js",
+  "sourceRoot": "../../../test/fixtures/",
+  "sources": [
+    "coffee1.coffee"
+  ],
+  "names": [],
+  "mappings": "AAAA;CAAA,KAAA,IAAA;;CAAA,CAAM;CACJ;;CAAA,EAAO,CAAP,EAAA,IAAC;;CAAD;;CADF;CAAA"
+}


### PR DESCRIPTION
The options object was being overwritten in the files.forEach loop, and so if the sourceMapDir wasn't specified, it would hold the value of the first file's destDir.

I don't think this is the optimal solution - see discussion in PR #111 - however I figured I'd fix the obvious variable clobbering first and then work on a better nesting solution.
