### PR TITLE
Fix sourceMappingURL paths.

### DIFF
--- a/tasks/coffee.js
+++ b/tasks/coffee.js
@@ -135,9 +135,9 @@ module.exports = function(grunt) {
   };
 
   var appendFooter = function(output, paths, options) {
-    // we need sourceMappingURL to be relative to the js path
-    var sourceMappingDir = paths.destDir.replace(/[^/]+/g, '..') + options.sourceMapDir;
-    // add sourceMappingURL to file footer
+    // We need the sourceMappingURL to be relative to the JS path
+    var sourceMappingDir = appendTrailingSlash(path.relative(paths.destDir, options.sourceMapDir));
+    // Add sourceMappingURL to file footer
     output.js = output.js + '\n//# sourceMappingURL=' + sourceMappingDir + paths.mapFileName + '\n';
   };
 

--- a/test/expected/eachMap/coffee1.js
+++ b/test/expected/eachMap/coffee1.js
@@ -12,4 +12,4 @@
 
 }).call(this);
 
-//# sourceMappingURL=../../tmp/eachMap/coffee1.js.map
+//# sourceMappingURL=coffee1.js.map

--- a/test/expected/eachMap/litcoffee.js
+++ b/test/expected/eachMap/litcoffee.js
@@ -7,4 +7,4 @@
 
 }).call(this);
 
-//# sourceMappingURL=../../tmp/eachMap/litcoffee.js.map
+//# sourceMappingURL=litcoffee.js.map

--- a/test/expected/maps/coffee.js
+++ b/test/expected/maps/coffee.js
@@ -12,4 +12,4 @@
 
 }).call(this);
 
-//# sourceMappingURL=../../tmp/maps/coffee.js.map
+//# sourceMappingURL=coffee.js.map

--- a/test/expected/maps/coffeeBare.js
+++ b/test/expected/maps/coffeeBare.js
@@ -9,4 +9,4 @@ HelloWorld = (function() {
 
 })();
 
-//# sourceMappingURL=../../tmp/maps/coffeeBare.js.map
+//# sourceMappingURL=coffeeBare.js.map

--- a/test/expected/maps/coffeeBareJoin.js
+++ b/test/expected/maps/coffeeBareJoin.js
@@ -11,4 +11,4 @@ HelloWorld = (function() {
 
 console.log('hi');
 
-//# sourceMappingURL=../../tmp/maps/coffeeBareJoin.js.map
+//# sourceMappingURL=coffeeBareJoin.js.map

--- a/test/expected/maps/coffeeJoin.js
+++ b/test/expected/maps/coffeeJoin.js
@@ -14,4 +14,4 @@
 
 }).call(this);
 
-//# sourceMappingURL=../../tmp/maps/coffeeJoin.js.map
+//# sourceMappingURL=coffeeJoin.js.map

--- a/test/expected/sourceMapDir1/coffee.js
+++ b/test/expected/sourceMapDir1/coffee.js
@@ -12,4 +12,4 @@
 
 }).call(this);
 
-//# sourceMappingURL=../../tmp/sourceMapDir2/coffee.js.map
+//# sourceMappingURL=../sourceMapDir2/coffee.js.map


### PR DESCRIPTION
This fixes issue #117, the rational is that you don't want the relative file path, you want a relative URL path. The sourceMappingURL is used by your browser to find the related map, not by anything else.

Let me know what you think,

Cheers, Dave.
