### PR TITLE
Adds the httpRoot option to fix sourceMappingUrl relative paths in the footer

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -127,6 +127,15 @@ module.exports = function(grunt) {
           'tmp/nest/1/coffee.js': ['test/fixtures/coffee1.coffee'],
           'tmp/nest/2/coffee.js': ['test/fixtures/coffee1.coffee']
         }
+      },
+      compileHttpRootDir: {
+        options: {
+          sourceMap: true,
+          httpRootDir: 'tmp/'
+        },
+        files: {
+          'tmp/httpRootDir/coffee.js': ['test/fixtures/coffee1.coffee']
+        }
       }
     },
 

--- a/tasks/coffee.js
+++ b/tasks/coffee.js
@@ -29,7 +29,7 @@ module.exports = function(grunt) {
       if (options.sourceMap === true) {
         var paths = createOutputPaths(f.dest);
         // add sourceMapDir to options object
-        var fileOptions = _.extend({ sourceMapDir: paths.destDir }, options);
+        var fileOptions = _.extend({ sourceMapDir: paths.destDir, httpRootDir: '' }, options);
         writeFileAndMap(paths, compileWithMaps(validFiles, fileOptions, paths), fileOptions);
       } else if (options.join === true) {
         writeFile(f.dest, concatInput(validFiles, options));
@@ -135,7 +135,9 @@ module.exports = function(grunt) {
 
   var appendFooter = function(output, paths, options) {
     // we need sourceMappingURL to be relative to the js path
-    var sourceMappingDir = paths.destDir.replace(/[^/]+/g, '..') + options.sourceMapDir;
+    var destDir = path.relative(options.httpRootDir, paths.destDir) + '/';
+    var sourceMapDir = path.relative(options.httpRootDir, options.sourceMapDir) + '/';
+    var sourceMappingDir = destDir.replace(/[^/]+/g, '..') + sourceMapDir;
     // add sourceMappingURL to file footer
     output.js = output.js + '\n//# sourceMappingURL=' + sourceMappingDir + paths.mapFileName + '\n';
   };

--- a/test/coffee_test.js
+++ b/test/coffee_test.js
@@ -202,4 +202,14 @@ exports.coffee = {
 
     test.done();
   },
+  compileHttpRootDir: function(test) {
+    test.expect(1);
+
+    assertFileEquality(test,
+      'tmp/httpRootDir/coffee.js',
+      'test/expected/httpRootDir/coffee.js',
+      'Compilation with the httpRootDir option should output the correct relative sourceMappingUrl');
+
+    test.done();
+  }
 };

--- a/test/expected/httpRootDir/coffee.js
+++ b/test/expected/httpRootDir/coffee.js
@@ -1,0 +1,15 @@
+(function() {
+  var HelloWorld;
+
+  HelloWorld = (function() {
+    function HelloWorld() {}
+
+    HelloWorld.test = 'test';
+
+    return HelloWorld;
+
+  })();
+
+}).call(this);
+
+//# sourceMappingURL=../httpRootDir/coffee.js.map


### PR DESCRIPTION
My current project is set up as follows:

```
Gruntfile.js
app/
----- assets/coffee
----- public/js
```

My coffee task looks like

```
files: [{
  expand: true,
  ext: '.js',
  cwd: 'app/assets/coffee',
  src: '**/*.coffee',
  dest: 'app/public/js'
}],
options: {
  sourceMap: true,
}
```

The generated js currently has a footer with

```
//# sourceMappingURL=../../../app/public/js/index.js.map
```

which is an invalid path, as my http root is app/.

This pull request creates a new option httpRootDir such that when it's set to 'app', the footer correctly reads

```
//# sourceMappingURL=../../public/js/index.js.map
```

Unit tested & manually tested with my own project.
