### PR TITLE
Update coffee-examples.md

### DIFF
--- a/docs/coffee-examples.md
+++ b/docs/coffee-examples.md
@@ -61,4 +61,4 @@ coffee: {
 }
 ```
 
-For more examples on how to use the `expand` API to manipulate the default dynamic path construction in the `glob_to_multiple` examples, see "Building the files object dynamically" in the grunt wiki entry [Configuring Tasks](http://gruntjs.com/configuring-tasks).
+For more examples on how to use the `expand` API to manipulate the default dynamic path construction in the `glob_to_multiple` examples, see "[Building the files object dynamically](http://gruntjs.com/configuring-tasks#building-the-files-object-dynamically)" in the grunt wiki entry [Configuring Tasks](http://gruntjs.com/configuring-tasks).


### PR DESCRIPTION
Just links to the "Building the files object dynamically" section directly, but still leaves the link to the Configuring Tasks page.
