### PR TITLE
Restoring log in all tasks

### DIFF
--- a/tasks/coffee.js
+++ b/tasks/coffee.js
@@ -33,9 +33,9 @@ module.exports = function(grunt) {
         var fileOptions = _.extend({ sourceMapDir: paths.destDir }, options);
         writeFileAndMap(paths, compileWithMaps(validFiles, fileOptions, paths), fileOptions);
       } else if (options.join === true) {
-        writeFile(f.dest, concatInput(validFiles, options));
+        writeCompiledFile(f.dest, concatInput(validFiles, options));
       } else {
-        writeFile(f.dest, concatOutput(validFiles, options));
+        writeCompiledFile(f.dest, concatOutput(validFiles, options));
       }
     });
   });


### PR DESCRIPTION
As said in issue #129, some configuration wasn't logging the list of files created.

It was just a simple function name to change, and now we have logging for each tasks.
## 

Fixes #129 
