### PR TITLE
Allow override of default map file extension (.map.js)

### DIFF
--- a/tasks/coffee.js
+++ b/tasks/coffee.js
@@ -19,6 +19,7 @@ module.exports = function(grunt) {
       join: false,
       sourceMap: false,
       joinExt: '.src.coffee',
+      mapExt: '.js.map',
       separator: grunt.util.linefeed
     });
 
@@ -28,7 +29,7 @@ module.exports = function(grunt) {
       var validFiles = removeInvalidFiles(f);
 
       if (options.sourceMap === true) {
-        var paths = createOutputPaths(f.dest);
+        var paths = createOutputPaths(f.dest, options);
         // add sourceMapDir to options object
         var fileOptions = _.extend({ sourceMapDir: paths.destDir }, options);
         writeFileAndMap(paths, compileWithMaps(validFiles, fileOptions, paths), fileOptions);
@@ -55,13 +56,13 @@ module.exports = function(grunt) {
     });
   };
 
-  var createOutputPaths = function(destination) {
+  var createOutputPaths = function(destination, options) {
     var fileName = path.basename(destination, path.extname(destination));
     return {
       dest: destination,
       destName: fileName,
       destDir: appendTrailingSlash(path.dirname(destination)),
-      mapFileName: fileName + '.js.map'
+      mapFileName: fileName + options.mapExt
     };
   };
 


### PR DESCRIPTION
Adds a 'mapExt' option, which defaults to '.js.map'
