### PR TITLE
fix(#154) Summary of created files resets after each report

### DIFF
--- a/tasks/coffee.js
+++ b/tasks/coffee.js
@@ -13,10 +13,14 @@ module.exports = function(grunt) {
   var chalk = require('chalk');
   var _ = require('lodash');
 
-  var actionCounts = {
-    fileCreated: 0,
-    mapCreated: 0
+  var actionCounts = {};
+  var resetCounts = function() {
+    actionCounts = {
+      fileCreated: 0,
+      mapCreated: 0
+    };
   };
+  resetCounts();
 
   grunt.registerMultiTask('coffee', 'Compile CoffeeScript files into JavaScript', function() {
     var options = this.options({
@@ -48,6 +52,7 @@ module.exports = function(grunt) {
     if (actionCounts.mapCreated > 0) {
       grunt.log.ok(actionCounts.mapCreated + ' source map files created.');
     }
+    resetCounts();
 
   });
 


### PR DESCRIPTION
bug appears fixed.
Solutions looks a little raw though.
In other projects I often have a stats class that I pull in to handle these simple increment, report, reset tasks.
Open to suggestions.

Another question should the actionCounts and resetCounts be defined above the module.exports ?
