### PR TITLE
Add "process" option for tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -60,6 +60,19 @@ module.exports = function(grunt) {
           'tmp/bare/concat.js': mixedConcatFixtures
         }
       },
+      compileProcessed: {
+        options: {
+          process: function(content, srcpath) {
+            return content.replace(/hi/g, 'hello').replace(/test/g, 'check');
+          }
+        },
+        files: {
+          'tmp/proc/coffee.js': ['test/fixtures/coffee1.coffee'],
+          'tmp/proc/litcoffee.js': ['test/fixtures/litcoffee.litcoffee'],
+          'tmp/proc/litcoffeemd.js': ['test/fixtures/litcoffee.coffee.md'],
+          'tmp/proc/proc.js': uniformConcatFixtures
+        }
+      },
       compileJoined: {
         options: {
           join: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# grunt-contrib-coffee v0.11.1 [![Build Status: Linux](https://travis-ci.org/gruntjs/grunt-contrib-coffee.png?branch=master)](https://travis-ci.org/gruntjs/grunt-contrib-coffee)
+# grunt-contrib-coffee v0.11.1 [![Build Status: Linux](https://travis-ci.org/gruntjs/grunt-contrib-coffee.png?branch=master)](https://travis-ci.org/gruntjs/grunt-contrib-coffee) <a href="https://ci.appveyor.com/project/gruntjs/grunt-contrib-coffee"><img src="https://ci.appveyor.com/api/projects/status/ns3waxwcw8ddcr3f/branch/master" alt="Build Status: Windows" height="18" /></a>
 
 > Compile CoffeeScript files to JavaScript.
 
@@ -38,6 +38,12 @@ Concatenated files will be joined on this string.
 Type: `boolean`
 
 Compile the JavaScript without the top-level function safety wrapper.
+
+#### process
+Type: `Function(content, srcpath)`
+Default: `false`
+
+Process file contents before compilation.
 
 #### join
 Type: `boolean`
@@ -83,6 +89,18 @@ coffee: {
       'path/to/another.js': ['path/to/sources/*.coffee', 'path/to/more/*.coffee'] // compile and concat into single file
     }
   },
+  
+  compileProcessed: {
+    options: {
+      process: function(content, srcpath) {
+        return content.replace(/text_to_find/g, 'text_to_replace');
+      }
+    },
+    files: {
+      'path/to/result.js': 'path/to/source.coffee', // replace all text occurrences and compile
+      'path/to/another.js': ['path/to/sources/*.coffee', 'path/to/more/*.coffee'] // replace all text occurrences, compile and concat into single file
+    }
+  }
 
   compileJoined: {
     options: {
@@ -161,4 +179,4 @@ For more examples on how to use the `expand` API to manipulate the default dynam
 
 Task submitted by [Eric Woroshow](http://ericw.ca/)
 
-*This file was generated on Fri Aug 15 2014 11:06:42.*
+*This file was generated on Tue Aug 19 2014 21:16:50.*

--- a/docs/coffee-examples.md
+++ b/docs/coffee-examples.md
@@ -18,6 +18,18 @@ coffee: {
       'path/to/another.js': ['path/to/sources/*.coffee', 'path/to/more/*.coffee'] // compile and concat into single file
     }
   },
+  
+  compileProcessed: {
+    options: {
+      process: function(content, srcpath) {
+        return content.replace(/text_to_find/g, 'text_to_replace');
+      }
+    },
+    files: {
+      'path/to/result.js': 'path/to/source.coffee', // replace all text occurrences and compile
+      'path/to/another.js': ['path/to/sources/*.coffee', 'path/to/more/*.coffee'] // replace all text occurrences, compile and concat into single file
+    }
+  }
 
   compileJoined: {
     options: {

--- a/docs/coffee-options.md
+++ b/docs/coffee-options.md
@@ -11,6 +11,12 @@ Type: `boolean`
 
 Compile the JavaScript without the top-level function safety wrapper.
 
+## process
+Type: `Function(content, srcpath)`
+Default: `false`
+
+Process file contents before compilation.
+
 ## join
 Type: `boolean`
 Default: `false`

--- a/tasks/coffee.js
+++ b/tasks/coffee.js
@@ -17,6 +17,7 @@ module.exports = function(grunt) {
     var options = this.options({
       bare: false,
       join: false,
+      process: false,
       sourceMap: false,
       joinExt: '.src.coffee',
       separator: grunt.util.linefeed
@@ -171,6 +172,10 @@ module.exports = function(grunt) {
     if (filepath) {
       coffeeOptions.filename = filepath;
       coffeeOptions.literate = isLiterate(path.extname(filepath));
+    }
+
+    if (_.isFunction(coffeeOptions.process)) {
+      code = coffeeOptions.process(code, coffeeOptions.filename);
     }
 
     try {

--- a/test/coffee_test.js
+++ b/test/coffee_test.js
@@ -172,6 +172,31 @@ exports.coffee = {
 
     test.done();
   },
+  compileProcessed: function(test) {
+    test.expect(4);
+
+    assertFileEquality(test,
+      'tmp/proc/coffee.js',
+      'test/expected/proc/coffee.js',
+      'Should replace all occurrences of "hi" to "hello" and "test" to "check" respectively, and compile coffeescript to javascript');
+
+    assertFileEquality(test,
+      'tmp/proc/litcoffee.js',
+      'test/expected/proc/litcoffee.js',
+      'Should replace all occurrences of "hi" to "hello" and "test" to "check" respectively, and compile literate coffeescript to wrapped javascript');
+
+    assertFileEquality(test,
+      'tmp/proc/litcoffeemd.js',
+      'test/expected/proc/litcoffeemd.js',
+      'Should replace all occurrences of "hi" to "hello" and "test" to "check" respectively, and compile literate coffeescript to wrapped javascript');
+
+    assertFileEquality(test,
+      'tmp/proc/proc.js',
+      'test/expected/proc/proc.js',
+      'Should replace all occurrences of "hi" to "hello" and "test" to "check" respectively, and compile coffeescript files with wrappers and concatenate them into a single javascript file');
+
+    test.done();
+  },
   compileSourceMapDir: function(test) {
     test.expect(2);
 

--- a/test/expected/proc/coffee.js
+++ b/test/expected/proc/coffee.js
@@ -1,0 +1,13 @@
+(function() {
+  var HelloWorld;
+
+  HelloWorld = (function() {
+    function HelloWorld() {}
+
+    HelloWorld.check = 'check';
+
+    return HelloWorld;
+
+  })();
+
+}).call(this);

--- a/test/expected/proc/litcoffee.js
+++ b/test/expected/proc/litcoffee.js
@@ -1,0 +1,8 @@
+(function() {
+  var sayHello;
+
+  sayHello = function() {
+    return console.log('hello');
+  };
+
+}).call(this);

--- a/test/expected/proc/litcoffeemd.js
+++ b/test/expected/proc/litcoffeemd.js
@@ -1,0 +1,8 @@
+(function() {
+  var sayHello;
+
+  sayHello = function() {
+    return console.log('hello');
+  };
+
+}).call(this);

--- a/test/expected/proc/proc.js
+++ b/test/expected/proc/proc.js
@@ -1,0 +1,18 @@
+(function() {
+  var HelloWorld;
+
+  HelloWorld = (function() {
+    function HelloWorld() {}
+
+    HelloWorld.check = 'check';
+
+    return HelloWorld;
+
+  })();
+
+}).call(this);
+
+(function() {
+  console.log('hello');
+
+}).call(this);


### PR DESCRIPTION
Sometimes it's necessary to replace some information in coffee files before compilation.
You could use some kind of macros in your files, e.g.:
> mongoose.connect('mongodb://__my_mongo_db_url__');

After that you could create dev build for local testing by replacing '__my_mongo_db_url__' to '__localhost/SomeLocalDB__'
or create production build replacing '__my_mongo_db_url__' to '__remotehost/SomeRemoteDB__'.
Also it could be some other cases that requires some replacements in the coffee files contents.

The same option already exists in [grunt-contrib-copy#process](https://github.com/gruntjs/grunt-contrib-copy#process), but it requires installing additional package and creating one more grunt task/watch to do simple replacement operation.