### PR TITLE
Normalize Windows paths with forward slashes for sourceRoot

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "dependencies": {
     "coffee-script": "~1.7.0",
     "chalk": "~0.5.0",
-    "lodash": "~2.4.1"
+    "lodash": "~2.4.1",
+    "uri-path": "0.0.2"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.10.0",

--- a/tasks/coffee.js
+++ b/tasks/coffee.js
@@ -12,6 +12,7 @@ module.exports = function(grunt) {
   var path = require('path');
   var chalk = require('chalk');
   var _ = require('lodash');
+  var uriPath = require('uri-path');
 
   grunt.registerMultiTask('coffee', 'Compile CoffeeScript files into JavaScript', function() {
     var options = this.options({
@@ -100,7 +101,7 @@ module.exports = function(grunt) {
 
     options = _.extend({
       generatedFile: path.basename(paths.dest),
-      sourceRoot: mapOptions.sourceRoot,
+      sourceRoot: uriPath(mapOptions.sourceRoot),
       sourceFiles: mapOptions.sourceFiles
     }, options);
 
@@ -149,7 +150,7 @@ module.exports = function(grunt) {
     // We need the sourceMappingURL to be relative to the JS path
     var sourceMappingDir = appendTrailingSlash(path.relative(paths.destDir, options.sourceMapDir));
     // Add sourceMappingURL to file footer
-    output.js = output.js + '\n//# sourceMappingURL=' + sourceMappingDir + paths.mapFileName + '\n';
+    output.js = output.js + '\n//# sourceMappingURL=' + uriPath(sourceMappingDir) + paths.mapFileName + '\n';
   };
 
   var concatInput = function(files, options) {


### PR DESCRIPTION
On Windows, the sourcemap file will be generated like 

`sourceRoot: "..\coffee\"`

other task like `grunt-contrib-uglify` which imports that sourcemap file will refer to a wrong sourcemap path.
