### PR TITLE
Support inline source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,9 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "coffee-script": "~1.7.0",
     "chalk": "~0.5.0",
+    "coffee-script": "~1.7.0",
+    "convert-source-map": "^0.4.1",
     "lodash": "~2.4.1"
   },
   "devDependencies": {

--- a/tasks/coffee.js
+++ b/tasks/coffee.js
@@ -12,7 +12,7 @@ module.exports = function(grunt) {
   var path = require('path');
   var chalk = require('chalk');
   var _ = require('lodash');
-  var convert = require("convert-source-map");
+  var convert = require('convert-source-map');
 
   grunt.registerMultiTask('coffee', 'Compile CoffeeScript files into JavaScript', function() {
     var options = this.options({
@@ -225,8 +225,9 @@ module.exports = function(grunt) {
       return;
     }
 
+    var createdFile = null;
     if (!options.inline) {
-      var createdFile = writeCompiledFile(paths.dest, output.js);
+      createdFile = writeCompiledFile(paths.dest, output.js);
       options.sourceMapDir = appendTrailingSlash(options.sourceMapDir);
       var createdMap = writeSourceMapFile(options.sourceMapDir + paths.mapFileName, output.v3SourceMap);
 
@@ -236,8 +237,8 @@ module.exports = function(grunt) {
       };
     } else {
       var comment = convert.fromObject(output.v3SourceMap).toComment();
-      output.js += "\n" + comment;
-      var createdFile = writeCompiledFile(paths.dest, output.js);
+      output.js += '\n' + comment;
+      createdFile = writeCompiledFile(paths.dest, output.js);
       
       return {
         createdFile: createdFile


### PR DESCRIPTION
Hi, for my purposes I prefer inline source maps instead of separate files. I've added an `inline` option and changed `coffee.js` accordingly.

Thanks for considering this feature.