### PR TITLE
Fixes multiple literate coffeescript files with `sourceMap: true`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -127,6 +127,24 @@ module.exports = function(grunt) {
           'tmp/nest/1/coffee.js': ['test/fixtures/coffee1.coffee'],
           'tmp/nest/2/coffee.js': ['test/fixtures/coffee1.coffee']
         }
+      },
+      compileMDCoffeeMaps: {
+        options: {
+          sourceMap: true,
+          joinExt: '.src.coffee.md'
+        },
+        files: [{
+          'tmp/litCoffeeMaps/mdcoffee.js':['test/fixtures/mdcoffee.coffee.md', 'test/fixtures/mdcoffee1.coffee.md'],
+        }]
+      },
+      compileLitCoffeeMaps: {
+        options: {
+          sourceMap: true,
+          joinExt: '.src.litcoffee'
+        },
+        files: [{
+          'tmp/litCoffeeMaps/litcoffee.js':['test/fixtures/litcoffee.litcoffee', 'test/fixtures/litcoffee1.litcoffee'],
+        }]
       }
     },
 

--- a/tasks/coffee.js
+++ b/tasks/coffee.js
@@ -173,6 +173,9 @@ module.exports = function(grunt) {
       coffeeOptions.filename = filepath;
       coffeeOptions.literate = isLiterate(path.extname(filepath));
     }
+    else {
+      coffeeOptions.literate = isLiterate(path.extname(options.joinExt));
+    }
 
     try {
       return require('coffee-script').compile(code, coffeeOptions);

--- a/test/coffee_test.js
+++ b/test/coffee_test.js
@@ -93,8 +93,8 @@ exports.coffee = {
     test.done();
   },
   compileMaps: function(test) {
+    
     test.expect(10);
-
     assertFileEquality(test,
       'tmp/maps/coffee.js',
       'test/expected/maps/coffee.js',
@@ -202,4 +202,34 @@ exports.coffee = {
 
     test.done();
   },
+  compileMDCoffeeMaps: function(test) {
+    test.expect(2);
+
+    assertFileEquality(test,
+      'tmp/litCoffeeMaps/mdcoffee.js',
+      'test/expected/litCoffeeMaps/mdcoffee.js',
+      'Compilation of multiple coffee.md files with maps should generate javascript');
+
+    assertFileEquality(test,
+      'tmp/litCoffeeMaps/mdcoffee.js.map',
+      'test/expected/litCoffeeMaps/mdcoffee.js.map',
+      'Compilation of multiple coffee.md files with maps should generate map');
+
+    test.done();
+  },
+  compileLitCoffeeMaps: function(test) {
+    test.expect(2);
+
+    assertFileEquality(test,
+      'tmp/litCoffeeMaps/litcoffee.js',
+      'test/expected/litCoffeeMaps/litcoffee.js',
+      'Compilation of multiple .litcoffee files with maps should generate javascript');
+
+    assertFileEquality(test,
+      'tmp/litCoffeeMaps/litcoffee.js.map',
+      'test/expected/litCoffeeMaps/litcoffee.js.map',
+      'Compilation of multiple .litcoffee files with maps should generate map');
+
+    test.done();
+  }
 };

--- a/test/expected/litCoffeeMaps/litcoffee.js
+++ b/test/expected/litCoffeeMaps/litcoffee.js
@@ -1,0 +1,14 @@
+(function() {
+  var sayHello;
+
+  sayHello = function() {
+    return console.log('hi');
+  };
+
+  sayHello = function() {
+    return console.log('I like to annotate my source with literated coffee.');
+  };
+
+}).call(this);
+
+//# sourceMappingURL=litcoffee.js.map

--- a/test/expected/litCoffeeMaps/litcoffee.js.map
+++ b/test/expected/litCoffeeMaps/litcoffee.js.map
@@ -1,0 +1,10 @@
+{
+  "version": 3,
+  "file": "litcoffee.js",
+  "sourceRoot": "",
+  "sources": [
+    "litcoffee.src.litcoffee"
+  ],
+  "names": [],
+  "mappings": "AAEI;AAAA,MAAA,QAAA;;AAAA,EAAA,QAAA,GAAW,SAAA,GAAA;WAIT,OAAO,CAAC,GAAR,CAAY,IAAZ,EAJS;EAAA,CAAX,CAAA;;AAAA,EAQA,QAAA,GAAW,SAAA,GAAA;WAIT,OAAO,CAAC,GAAR,CAAY,qDAAZ,EAJS;EAAA,CARX,CAAA;AAAA"
+}

--- a/test/expected/litCoffeeMaps/mdcoffee.js
+++ b/test/expected/litCoffeeMaps/mdcoffee.js
@@ -1,0 +1,14 @@
+(function() {
+  var sayHello;
+
+  sayHello = function() {
+    return console.log('hi');
+  };
+
+  sayHello = function() {
+    return console.log('I like to annotate my source with literated coffee.');
+  };
+
+}).call(this);
+
+//# sourceMappingURL=mdcoffee.js.map

--- a/test/expected/litCoffeeMaps/mdcoffee.js.map
+++ b/test/expected/litCoffeeMaps/mdcoffee.js.map
@@ -1,0 +1,10 @@
+{
+  "version": 3,
+  "file": "mdcoffee.js",
+  "sourceRoot": "",
+  "sources": [
+    "mdcoffee.src.coffee.md"
+  ],
+  "names": [],
+  "mappings": "AAEI;AAAA,MAAA,QAAA;;AAAA,EAAA,QAAA,GAAW,SAAA,GAAA;WAIT,OAAO,CAAC,GAAR,CAAY,IAAZ,EAJS;EAAA,CAAX,CAAA;;AAAA,EAQA,QAAA,GAAW,SAAA,GAAA;WAIT,OAAO,CAAC,GAAR,CAAY,qDAAZ,EAJS;EAAA,CARX,CAAA;AAAA"
+}

--- a/test/fixtures/litcoffee1.litcoffee
+++ b/test/fixtures/litcoffee1.litcoffee
@@ -1,0 +1,7 @@
+Begin function declaration.
+
+    sayHello = ->
+
+Print a greeting.
+
+      console.log 'I like to annotate my source with literated coffee.'

--- a/test/fixtures/mdcoffee.coffee.md
+++ b/test/fixtures/mdcoffee.coffee.md
@@ -1,0 +1,7 @@
+Begin function declaration.
+
+    sayHello = ->
+
+Print a greeting.
+
+      console.log 'hi'

--- a/test/fixtures/mdcoffee1.coffee.md
+++ b/test/fixtures/mdcoffee1.coffee.md
@@ -1,0 +1,7 @@
+Begin function declaration.
+
+    sayHello = ->
+
+Print a greeting.
+
+      console.log 'I like to annotate my source with literated coffee.'


### PR DESCRIPTION
Fixing task to recognize .litcoffee and .coffee.md when `sourceMap: true`.

Originally, multiple `.litcoffee` and `.coffee.md` files where compiling into the default `fileExt: '.src.coffee'`.  Now when there are multiple literate coffescript files and  the "joinExt" src.litcoffee" or ".coffee.md" is provided, the tasks recognize the concatenated script as literate coffee script.
