### PR TITLE
Use 'options.sourceMapDir' when creating the 'sourceRoot'

### DIFF
--- a/tasks/coffee.js
+++ b/tasks/coffee.js
@@ -95,7 +95,7 @@ module.exports = function(grunt) {
     if (files.length > 1) {
       mapOptions = createOptionsForJoin(files, paths, options.separator, options.joinExt);
     } else {
-      mapOptions = createOptionsForFile(files[0], paths);
+      mapOptions = createOptionsForFile(files[0], paths, options);
       filepath = files[0];
     }
 
@@ -138,11 +138,11 @@ module.exports = function(grunt) {
     return files.map(grunt.file.read).join(separator);
   };
 
-  var createOptionsForFile = function(file, paths) {
+  var createOptionsForFile = function(file, paths, options) {
     return {
       code: grunt.file.read(file),
       sourceFiles: [path.basename(file)],
-      sourceRoot: appendTrailingSlash(path.relative(paths.destDir, path.dirname(file)))
+      sourceRoot: appendTrailingSlash(path.relative(options.sourceMapDir, path.dirname(file)))
     };
   };
 


### PR DESCRIPTION
Instead of using 'paths.destDir' (the default value of 'options.sourceMapDir').