### PR TITLE
Compilation loop is skipped if no files matched.

### DIFF
--- a/tasks/coffee.js
+++ b/tasks/coffee.js
@@ -31,6 +31,11 @@ module.exports = function(grunt) {
 
     this.files.forEach(function(f) {
       var validFiles = removeInvalidFiles(f);
+      
+      if (validFiles.length === 0) {
+        grunt.log.warn('Destination ' + chalk.cyan(f.dest) + ' not written because no source files were found.');
+        return;
+      }
 
       if (options.sourceMap === true) {
         var paths = createOutputPaths(f.dest);


### PR DESCRIPTION
Behavior and output is now consistent with grunt-contrib-less behavior. Fixes #184.