### PR TITLE
Bump coffee-script to 1.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "chalk": "^1.1.1",
-    "coffee-script": "^1.10.0",
+    "coffee-script": "^1.11.1",
     "lodash": "^4.6.1",
     "uri-path": "^1.0.0"
   },


### PR DESCRIPTION
This mainly allows modules imports/exports.

One idea to avoid this kind of pull would be to have `coffee-script` as a peerDependencie. Thoughts?