### PR TITLE
Update for Latest CoffeeScript

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v1.1.0:
+  date: 2017-02-24
+  changes:
+    - Updates to CoffeeScript 1.12.4.
 v1.0.0:
   date: 2016-02-15
   changes:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,7 @@
  * grunt-contrib-coffee
  * http://gruntjs.com/
  *
- * Copyright (c) 2016 Eric Woroshow, contributors
+ * Copyright (c) 2017 Eric Woroshow, contributors
  * Licensed under the MIT license.
  */
 

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2016 Eric Woroshow, contributors
+Copyright (c) 2017 Eric Woroshow, contributors
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ For more examples on how to use the `expand` API to manipulate the default dynam
 
 ## Release History
 
+ * 2017-02-24   v1.1.0   Updates to CoffeeScript 1.12.4.
  * 2016-02-15   v1.0.0   Updates to CoffeeScript 1.10.0. Update other dependencies. Use `options.sourceMapDir` when creating `sourceRoot`. Logs information if no valid files were matched.
  * 2015-02-20   v0.13.0   Updates to CoffeeScript 1.9.1.
  * 2014-10-04   v0.12.0   Fixes litcoffee sourcemaps. Updates to CoffeeScript 1.8.0.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "chalk": "^1.1.1",
-    "coffee-script": "^1.11.1",
+    "coffee-script": "^1.12.4",
     "lodash": "^4.6.1",
     "uri-path": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-contrib-coffee",
   "description": "Compile CoffeeScript files to JavaScript",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Grunt Team",
     "url": "http://gruntjs.com/"

--- a/tasks/coffee.js
+++ b/tasks/coffee.js
@@ -2,7 +2,7 @@
  * grunt-contrib-coffee
  * http://gruntjs.com/
  *
- * Copyright (c) 2016 Eric Woroshow, contributors
+ * Copyright (c) 2017 Eric Woroshow, contributors
  * Licensed under the MIT license.
  */
 


### PR DESCRIPTION
Did a few quick changes to bring this up to speed on the latest CoffeeScript version.  I also went ahead and updated the versioning of the plugin itself, increasing the minor version.

I had failing tests on my system; CoffeeScript was emitting files with no return-carriage character, which was not part of the expectations.  I used [travis.ci](https://travis-ci.org/JHawkley/grunt-contrib-coffee) to confirm, but the tests all passed there, so it must only be an environmental thing on my system.