### PR TITLE
Remove deprecation warning during `npm install`

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "chalk": "^1.1.1",
-    "coffee-script": "^1.11.1",
+    "coffee-script": "1.12.6",
     "lodash": "^4.6.1",
     "uri-path": "^1.0.0"
   },


### PR DESCRIPTION
I realize this shouldn't be strictly necessary, because the loose semver range should pick up this version bump automatically.  However, this commit pins the coffee-script dep at 1.12.6 to make sure (especially with some of the NPM 5 edge case issues folks have been experiencing as of late).  It also locks to an exact dependency, for the same reasons as laid out here in [this PR](https://github.com/gruntjs/grunt/pull/1598) to the main `grunt` package: https://github.com/gruntjs/grunt/issues/1556#issuecomment-315189532